### PR TITLE
Specify version number of transformer package

### DIFF
--- a/experiments.ipynb
+++ b/experiments.ipynb
@@ -32,7 +32,7 @@
     {
       "cell_type": "code",
       "source": [
-        "!pip install diffusers==0.6 transformers"
+        "!pip install diffusers==0.6 transformers==4.24.0"
       ],
       "metadata": {
         "id": "YHkkK2wQalyj"


### PR DESCRIPTION
Fix the following error by setting the version number of the transformer package to 4.24.0

`ValueError: The component <class 'transformers.models.clip.feature_extraction_clip.CLIPFeatureExtractor'> of <class 'diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion.StableDiffusionPipeline'> cannot be loaded as it does not seem to have any of the loading methods defined in {'ModelMixin': ['save_pretrained', 'from_pretrained'], 'SchedulerMixin': ['save_config', 'from_config'], 'DiffusionPipeline': ['save_pretrained', 'from_pretrained'], 'OnnxRuntimeModel': ['save_pretrained', 'from_pretrained'], 'PreTrainedTokenizer': ['save_pretrained', 'from_pretrained'], 'PreTrainedTokenizerFast': ['save_pretrained', 'from_pretrained'], 'PreTrainedModel': ['save_pretrained', 'from_pretrained'], 'FeatureExtractionMixin': ['save_pretrained', 'from_pretrained']}.`

CLIPFeatureExtractor is deprecated since v4.26.0 and v4.25.0 is yanked -> set to v4.24.0